### PR TITLE
Bugfix of user editing (backend)

### DIFF
--- a/Backend/src/main/java/se/backend/service/user/UserMainService.java
+++ b/Backend/src/main/java/se/backend/service/user/UserMainService.java
@@ -48,10 +48,12 @@ public class UserMainService implements  UserService {
 
         editedInfo.setEmail(editedInfo.getEmail().toLowerCase());
 
-        if(userAccountRepository.existsByAssociatedEmail(editedInfo.getEmail()))
+        if(!editedInfo.getEmail().equals(originalAccount.get().getAssociatedEmail()) &&
+                userAccountRepository.existsByAssociatedEmail(editedInfo.getEmail()))
             return new Pair<>(null, "Email is already used");
 
-        if(userAccountRepository.existsByName(editedInfo.getName()))
+        if(!editedInfo.getName().equals(originalAccount.get().getName()) &&
+                userAccountRepository.existsByName(editedInfo.getName()))
             return new Pair<>(null, "Name is already used");
 
         if(!StringUtils.IsStringAPhoneNumber(editedInfo.getPhoneNumber()))

--- a/Backend/src/test/java/controller/internal/UserControllerTest.java
+++ b/Backend/src/test/java/controller/internal/UserControllerTest.java
@@ -57,6 +57,7 @@ public class UserControllerTest {
     public void EditUserTest() throws Exception {
         MockMultipartFile validData = new MockMultipartFile("userdata", "", "application/json", "{\"name\":\"NewName\",\"phoneNumber\":\"788 640 000\", \"email\":\"new@mail.com\"}".getBytes());
         MockMultipartFile usedData = new MockMultipartFile("userdata", "", "application/json", "{\"name\":\"Bill Gates\",\"phoneNumber\":\"788 640 000\", \"email\":\"new@mail.com\"}".getBytes());
+        MockMultipartFile validDataOnlyNameChanged = new MockMultipartFile("userdata", "", "application/json", "{\"name\":\"New Name 2\",\"phoneNumber\":\"788 640 000\", \"email\":\"new@mail.com\"}".getBytes());
 
         MockMultipartHttpServletRequestBuilder updateBuilder;
 
@@ -116,5 +117,19 @@ public class UserControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("successful", is(true)))
                 .andExpect(jsonPath("data.name", is("NewName")));
+
+        //Successful edit changing only name
+        updateBuilder = MockMvcRequestBuilders.multipart("/user/10001");
+        updateBuilder.with(request -> {
+            request.setMethod("PUT");
+            return request;
+        });
+        mockMvc.perform(
+                updateBuilder
+                        .file(validDataOnlyNameChanged)
+                        .header(LoginService.authorizationHeader, "regularUserTestToken"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("successful", is(true)))
+                .andExpect(jsonPath("data.name", is("New Name 2")));
     }
 }

--- a/Backend/src/test/java/service/UserServiceTest.java
+++ b/Backend/src/test/java/service/UserServiceTest.java
@@ -43,8 +43,13 @@ public class UserServiceTest {
         assertEquals("Email is invalid", result.getValue1());
         assertNull(result.getValue0());
 
+        userInfo.setEmail("b.gates@mail.com");
+        result = userService.EditUser(10001, userInfo);
+        assertEquals("Email is already used", result.getValue1());
+        assertNull(result.getValue0());
+
         userInfo.setEmail("new@mail.com");
-        userInfo.setName("Elon Musk");
+        userInfo.setName("Bill Gates");
         result = userService.EditUser(10001, userInfo);
         assertEquals("Name is already used", result.getValue1());
         assertNull(result.getValue0());
@@ -71,9 +76,31 @@ public class UserServiceTest {
         assertEquals("User does not exist", result.getValue1());
         assertNull(result.getValue0());
 
+        //Proper update
         result = userService.EditUser(10001, userInfo);
         assertEquals("", result.getValue1());
         assertNotNull(result.getValue0());
         assertEquals("+48 788 64 00 00", result.getValue0().getPhoneNumber());
+
+        //Update ONLY name
+        userInfo.setName("New Name 2");
+        result = userService.EditUser(10001, userInfo);
+        assertEquals("", result.getValue1());
+        assertNotNull(result.getValue0());
+        assertEquals("New Name 2", result.getValue0().getName());
+
+        //Update ONLY email
+        userInfo.setEmail("even.newer@email.com");
+        result = userService.EditUser(10001, userInfo);
+        assertEquals("", result.getValue1());
+        assertNotNull(result.getValue0());
+        assertEquals("even.newer@email.com", result.getValue0().getEmail());
+
+        //Update ONLY phone number
+        userInfo.setPhoneNumber("784092997");
+        result = userService.EditUser(10001, userInfo);
+        assertEquals("", result.getValue1());
+        assertNotNull(result.getValue0());
+        assertEquals("784092997", result.getValue0().getPhoneNumber());
     }
 }


### PR DESCRIPTION
Bug: You could edit the user only if you were editing name and email at the same time
- [x] Fixed
- [x] Added tests to cover this case